### PR TITLE
Additional example how to use the Gstreamer in Java

### DIFF
--- a/GstFX/AppSinkListener
+++ b/GstFX/AppSinkListener
@@ -1,0 +1,64 @@
+
+import java.nio.ByteBuffer;
+
+import org.freedesktop.gstreamer.Buffer;
+import org.freedesktop.gstreamer.Sample;
+import org.freedesktop.gstreamer.Structure;
+import org.freedesktop.gstreamer.elements.AppSink;
+
+
+import javafx.scene.image.Image;
+import javafx.scene.image.PixelFormat;
+import javafx.scene.image.PixelWriter;
+import javafx.scene.image.WritableImage;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+
+
+public class AppSinkListener implements AppSink.NEW_SAMPLE {
+	
+	Image actualFrame;
+	int i = 0;
+	int lastWidth = 0;
+	int lastHeigth = 0;
+	byte[] byteArray;
+	public ObjectProperty<Image> frame = new SimpleObjectProperty<Image>(actualFrame);
+	private ImageContainer imageContainer = new ImageContainer();
+	
+	@Override
+	public void newBuffer(AppSink appSink) {
+		Sample sample = appSink.pullSample();
+		Structure capsStruct = sample.getCaps().getStructure(0);
+        Buffer buffer = sample.getBuffer();
+        ByteBuffer byteBuffer = buffer.map(false);
+        if (byteBuffer != null){
+            int width = capsStruct.getInteger("width");
+            int height = capsStruct.getInteger("height");
+        	if (width != lastWidth || height != lastHeigth){
+        		lastWidth = width;
+        		lastHeigth = height;
+        		byteArray = new byte[width * height * 4];
+        	}
+
+	        byteBuffer.get(byteArray);
+	        actualFrame = convertBytesToImage(byteArray, width, height);
+	        frame = new SimpleObjectProperty<Image>(actualFrame);
+	        imageContainer.setImage(actualFrame);
+	        buffer.unmap();
+	        }
+        sample.dispose();
+	}
+	
+	public ImageContainer getImageContainer(){
+		return imageContainer;
+	}
+
+	private Image convertBytesToImage(byte[] pixels, int width, int height){
+		WritableImage img = new WritableImage(width, height);
+		PixelWriter pw = img.getPixelWriter();
+		pw.setPixels(0, 0, width, height, PixelFormat.getByteBgraInstance(), pixels, 0, width *4);
+		return img;
+	}
+	
+}

--- a/GstFX/GstRenderer.java
+++ b/GstFX/GstRenderer.java
@@ -17,6 +17,8 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 
+// This example should give an idea how to render a Video provided by the Gstreamer to a frame in JavaFX.
+
 public class GstRenderer extends Application{
 	private ImageView imageView;
 	private AppSink videosink;
@@ -70,15 +72,6 @@ public class GstRenderer extends Application{
 		primaryStage.setTitle("Drawing Operations Test");
 		BorderPane grid = new BorderPane();
 		grid.setCenter(imageView);
-		imageView.viewportProperty().addListener(new ChangeListener<Rectangle2D>() {
-
-			@Override
-			public void changed(ObservableValue<? extends Rectangle2D> observable, Rectangle2D oldValue,
-					Rectangle2D newValue) {
-				System.out.println(newValue);
-			}
-
-		});
 	    imageView.fitWidthProperty().bind(grid.widthProperty()); 
 	    imageView.fitHeightProperty().bind(grid.heightProperty()); 
 	    imageView.setPreserveRatio(true);
@@ -90,9 +83,5 @@ public class GstRenderer extends Application{
         Gst.init("CameraTest",args);
         launch(args);
     }
-	
-	public void print(Image image){
-		imageView.setImage(image);
-	}
 
 }

--- a/GstFX/GstRenderer.java
+++ b/GstFX/GstRenderer.java
@@ -1,0 +1,98 @@
+import java.nio.ByteOrder;
+
+import org.freedesktop.gstreamer.Bin;
+import org.freedesktop.gstreamer.Caps;
+import org.freedesktop.gstreamer.Gst;
+import org.freedesktop.gstreamer.Pipeline;
+import org.freedesktop.gstreamer.elements.AppSink;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.geometry.Rectangle2D;
+import javafx.scene.Scene;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+
+public class GstRenderer extends Application{
+	private ImageView imageView;
+	private AppSink videosink;
+	private Pipeline pipe;
+	private Bin bin;
+	private StringBuilder caps;
+	private ImageContainer imageContainer;
+	public GstRenderer() {
+		videosink = new AppSink("GstVideoComponent");
+        videosink.set("emit-signals", true);
+        AppSinkListener GstListener = new AppSinkListener();
+        videosink.connect(GstListener);
+        caps = new StringBuilder("video/x-raw, ");
+        // JNA creates ByteBuffer using native byte order, set masks according to that.
+        if (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN) {
+            caps.append("format=BGRx");
+        } else {
+            caps.append("format=xRGB");
+        }
+        videosink.setCaps(new Caps(caps.toString()));
+        //?
+        videosink.set("max-buffers", 5000);
+        videosink.set("drop", true);
+        bin = Bin.launch("autovideosrc ! videoconvert ", true);
+        pipe = new Pipeline();
+        pipe.addMany(bin, videosink);
+        Pipeline.linkMany(bin, videosink);
+        pipe.play();
+        imageView = new ImageView();
+        
+        imageContainer = GstListener.getImageContainer();
+        imageContainer.addListener(new ChangeListener<Image>() {
+
+			@Override
+			public void changed(ObservableValue<? extends Image> observable, Image oldValue,
+					Image newValue) {
+				Platform.runLater(new Runnable() {
+					@Override
+					public void run() {
+						imageView.setImage(newValue);
+					}
+				});
+				
+			}
+        	
+		});
+	}
+
+	@Override
+	public void start(Stage primaryStage) throws Exception {
+		primaryStage.setTitle("Drawing Operations Test");
+		BorderPane grid = new BorderPane();
+		grid.setCenter(imageView);
+		imageView.viewportProperty().addListener(new ChangeListener<Rectangle2D>() {
+
+			@Override
+			public void changed(ObservableValue<? extends Rectangle2D> observable, Rectangle2D oldValue,
+					Rectangle2D newValue) {
+				System.out.println(newValue);
+			}
+
+		});
+	    imageView.fitWidthProperty().bind(grid.widthProperty()); 
+	    imageView.fitHeightProperty().bind(grid.heightProperty()); 
+	    imageView.setPreserveRatio(true);
+		primaryStage.setScene(new Scene(grid, 460, 460));
+        primaryStage.show();
+	}
+	
+	public static void main(String[] args) {
+        Gst.init("CameraTest",args);
+        launch(args);
+    }
+	
+	public void print(Image image){
+		imageView.setImage(image);
+	}
+
+}

--- a/GstFX/ImageContainer.java
+++ b/GstFX/ImageContainer.java
@@ -1,0 +1,22 @@
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.scene.image.Image;
+import javafx.scene.image.WritableImage;
+
+public class ImageContainer {
+	private ObjectProperty<Image> image = new SimpleObjectProperty<Image>();
+
+
+	public Image getImage() {
+		return image.get();
+	}
+
+	public void setImage(Image image) {
+		this.image.set(image);
+	}
+	
+	public void addListener(ChangeListener<Image> listener){
+		image.addListener(listener);
+	}
+}


### PR DESCRIPTION
This example provides the basic way of how to render a video from the GStreamer in a frame in JavaFX.
Since Swing get's replaced by JavaFX it is maybe interesting for others to see how this can be done.